### PR TITLE
Fix: Always require verification of checksum in Homebrew

### DIFF
--- a/dependencies/brew.sh
+++ b/dependencies/brew.sh
@@ -25,7 +25,7 @@ install_home_brew() {
 install_brew() {
     if [[ ! $(brew list -1 | grep "^$1$") ]]; then
         print_info "Installing $1"
-        brew install $1 >/dev/null
+        brew install --require-sha $1 >/dev/null
         print_success "${font_bold} ✓ installed. ${font_normal}"
     else
         print_success "$1 already installed."
@@ -35,7 +35,7 @@ install_brew() {
 install_cask() {
     if [[ ! $(brew list --cask -1 | grep "^$1$") ]]; then
         print_info "Installing $1"
-        brew install --cask $1 --appdir=/Applications >/dev/null
+        brew install --require-sha --cask $1 --appdir=/Applications >/dev/null
         print_success "${bold} ✓ installed. $1 ${normal}"
     else
         print_success "$1 already installed."

--- a/utils/version.sh
+++ b/utils/version.sh
@@ -1,1 +1,1 @@
-UP_VERSION="0.4.0"
+UP_VERSION="0.4.1"


### PR DESCRIPTION
## Summary

Fixes an issue where it's possible for a brew `formula` or `cask` to have disabled integrity verification. 

See [jiggler](https://github.com/Homebrew/homebrew-cask/blob/8fb59a41946b7459eb722fc1623529a6cc069fec/Casks/j/jiggler.rb#L3) example:
![image](https://github.com/mikeguta/macup/assets/7657388/68a443ca-f9ca-4c3d-ab9e-378354f8a9dd)

This is what would happen if we attempted its installation.
![image](https://github.com/mikeguta/macup/assets/7657388/5ae19f75-db71-4713-b589-b1658fa37ee6)